### PR TITLE
Add name query parameter for search command

### DIFF
--- a/src/main/java/tutorly/logic/commands/SearchCommand.java
+++ b/src/main/java/tutorly/logic/commands/SearchCommand.java
@@ -1,6 +1,7 @@
 package tutorly.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static tutorly.logic.parser.CliSyntax.PREFIX_NAME;
 
 import tutorly.commons.util.ToStringBuilder;
 import tutorly.logic.Messages;
@@ -17,8 +18,8 @@ public class SearchCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Searches for all students whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Parameters: " + PREFIX_NAME + "KEYWORD [KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie";
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/tutorly/logic/parser/SearchCommandParser.java
+++ b/src/main/java/tutorly/logic/parser/SearchCommandParser.java
@@ -1,8 +1,10 @@
 package tutorly.logic.parser;
 
 import static tutorly.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tutorly.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import tutorly.logic.commands.SearchCommand;
 import tutorly.logic.parser.exceptions.ParseException;
@@ -19,13 +21,17 @@ public class SearchCommandParser implements Parser<SearchCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public SearchCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+        Optional<String> query = argMultimap.getValue(PREFIX_NAME);
+
+        if (query.isEmpty() || query.get().isBlank() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
+
+        String[] nameKeywords = query.get().trim().split("\\s+");
 
         return new SearchCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }

--- a/src/test/java/tutorly/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/tutorly/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tutorly.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tutorly.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static tutorly.logic.parser.CliSyntax.PREFIX_NAME;
 import static tutorly.testutil.Assert.assertThrows;
 import static tutorly.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -72,7 +73,8 @@ public class AddressBookParserTest {
     public void parseCommand_search() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         SearchCommand command = (SearchCommand) parser.parseCommand(
-                SearchCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                SearchCommand.COMMAND_WORD + " " + PREFIX_NAME
+                        + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new SearchCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/tutorly/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/tutorly/logic/parser/SearchCommandParserTest.java
@@ -1,6 +1,9 @@
 package tutorly.logic.parser;
 
 import static tutorly.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tutorly.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static tutorly.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static tutorly.logic.parser.CliSyntax.PREFIX_NAME;
 import static tutorly.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static tutorly.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -17,7 +20,22 @@ public class SearchCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+        assertParseFailure(
+                parser,
+                "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+        assertParseFailure(
+                parser,
+                PREFIX_NAME + "  ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_preamblePresent_throwsParseException() {
+        assertParseFailure(
+                parser,
+                PREAMBLE_NON_EMPTY + NAME_DESC_AMY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -25,10 +43,10 @@ public class SearchCommandParserTest {
         // no leading and trailing whitespaces
         SearchCommand expectedSearchCommand =
                 new SearchCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedSearchCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedSearchCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedSearchCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t", expectedSearchCommand);
     }
 
 }


### PR DESCRIPTION
Closes #54 

Updates search command from `search Alice Bob` to `search n/Alice Bob`, in preparation for allowing searching of multiple fields of a student e.g. phone number.