### PR TITLE
Fix student ID reset after edit

### DIFF
--- a/src/main/java/tutorly/logic/commands/EditCommand.java
+++ b/src/main/java/tutorly/logic/commands/EditCommand.java
@@ -84,7 +84,9 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Memo updatedMemo = editPersonDescriptor.getMemo().orElse(personToEdit.getMemo());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedMemo);
+        Person person = new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedMemo);
+        person.setId(personToEdit.getId());
+        return person;
     }
 
     @Override


### PR DESCRIPTION
Student ID resets after an edit. We don't want that. This PR fixes that. 