### PR TITLE
Implement subcommands and subparsers

### DIFF
--- a/src/main/java/tutorly/logic/LogicManager.java
+++ b/src/main/java/tutorly/logic/LogicManager.java
@@ -47,7 +47,7 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
+        Command command = addressBookParser.parse(commandText);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/tutorly/logic/commands/AddSessionCommand.java
+++ b/src/main/java/tutorly/logic/commands/AddSessionCommand.java
@@ -13,15 +13,17 @@ import tutorly.model.session.Session;
 /**
  * Creates a new tutoring session.
  */
-public class CreateSessionCommand extends Command {
+public class AddSessionCommand extends SessionCommand {
 
-    public static final String COMMAND_WORD = "createSession";
+    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_STRING = SessionCommand.COMMAND_STRING + " " + COMMAND_WORD;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a tutoring session. "
+    public static final String MESSAGE_USAGE = COMMAND_STRING
+            + ": Creates a tutoring session. "
             + "Parameters: "
             + PREFIX_DATE + "DATE "
             + PREFIX_SUBJECT + "SUBJECT\n"
-            + "Example: " + COMMAND_WORD + " "
+            + "Example: " + COMMAND_STRING + " "
             + PREFIX_DATE + "2025-03-18 "
             + PREFIX_SUBJECT + "Mathematics";
 
@@ -35,7 +37,7 @@ public class CreateSessionCommand extends Command {
      *
      * @param session The session to be created.
      */
-    public CreateSessionCommand(Session session) {
+    public AddSessionCommand(Session session) {
         requireNonNull(session);
         toCreate = session;
     }
@@ -58,11 +60,11 @@ public class CreateSessionCommand extends Command {
             return true;
         }
 
-        if (!(other instanceof CreateSessionCommand)) {
+        if (!(other instanceof AddSessionCommand)) {
             return false;
         }
 
-        CreateSessionCommand otherCommand = (CreateSessionCommand) other;
+        AddSessionCommand otherCommand = (AddSessionCommand) other;
         return toCreate.equals(otherCommand.toCreate);
     }
 

--- a/src/main/java/tutorly/logic/commands/AddStudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/AddStudentCommand.java
@@ -17,11 +17,13 @@ import tutorly.model.person.Person;
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends Command {
+public class AddStudentCommand extends StudentCommand {
 
     public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_STRING = StudentCommand.COMMAND_STRING + " " + COMMAND_WORD;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a student to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_STRING
+            + ": Adds a student to the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_PHONE + "PHONE] "
@@ -29,7 +31,7 @@ public class AddCommand extends Command {
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]... "
             + "[" + PREFIX_MEMO + "MEMO]\n"
-            + "Example: " + COMMAND_WORD + " "
+            + "Example: " + COMMAND_STRING + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
@@ -46,7 +48,7 @@ public class AddCommand extends Command {
     /**
      * Creates an AddCommand to add the specified {@code Person}
      */
-    public AddCommand(Person person) {
+    public AddStudentCommand(Person person) {
         requireNonNull(person);
         toAdd = person;
     }
@@ -70,7 +72,7 @@ public class AddCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AddCommand otherAddCommand)) {
+        if (!(other instanceof AddStudentCommand otherAddCommand)) {
             return false;
         }
 

--- a/src/main/java/tutorly/logic/commands/ClearCommand.java
+++ b/src/main/java/tutorly/logic/commands/ClearCommand.java
@@ -11,6 +11,8 @@ import tutorly.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
+    public static final String COMMAND_STRING = COMMAND_WORD;
+
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
 

--- a/src/main/java/tutorly/logic/commands/DeleteStudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/DeleteStudentCommand.java
@@ -14,20 +14,21 @@ import tutorly.model.person.Person;
 /**
  * Deletes a person identified using it's displayed index from the address book.
  */
-public class DeleteCommand extends Command {
+public class DeleteStudentCommand extends StudentCommand {
 
     public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_STRING = StudentCommand.COMMAND_STRING + " " + COMMAND_WORD;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = COMMAND_STRING
             + ": Deletes and archive the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + COMMAND_STRING + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
     private final Index targetIndex;
 
-    public DeleteCommand(Index targetIndex) {
+    public DeleteStudentCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -52,11 +53,11 @@ public class DeleteCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof DeleteCommand)) {
+        if (!(other instanceof DeleteStudentCommand)) {
             return false;
         }
 
-        DeleteCommand otherDeleteCommand = (DeleteCommand) other;
+        DeleteStudentCommand otherDeleteCommand = (DeleteStudentCommand) other;
         return targetIndex.equals(otherDeleteCommand.targetIndex);
     }
 

--- a/src/main/java/tutorly/logic/commands/EditStudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/EditStudentCommand.java
@@ -33,11 +33,13 @@ import tutorly.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditCommand extends Command {
+public class EditStudentCommand extends StudentCommand {
 
     public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_STRING = StudentCommand.COMMAND_STRING + " " + COMMAND_WORD;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the student identified "
+    public static final String MESSAGE_USAGE = COMMAND_STRING
+            + ": Edits the details of the student identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
@@ -47,7 +49,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]... "
             + "[" + PREFIX_MEMO + "MEMO]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
+            + "Example: " + COMMAND_STRING + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
@@ -62,7 +64,7 @@ public class EditCommand extends Command {
      * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
-    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    public EditStudentCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
@@ -117,7 +119,7 @@ public class EditCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditCommand otherEditCommand)) {
+        if (!(other instanceof EditStudentCommand otherEditCommand)) {
             return false;
         }
 

--- a/src/main/java/tutorly/logic/commands/ExitCommand.java
+++ b/src/main/java/tutorly/logic/commands/ExitCommand.java
@@ -8,6 +8,7 @@ import tutorly.model.Model;
 public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
+    public static final String COMMAND_STRING = COMMAND_WORD;
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
 

--- a/src/main/java/tutorly/logic/commands/HelpCommand.java
+++ b/src/main/java/tutorly/logic/commands/HelpCommand.java
@@ -8,6 +8,7 @@ import tutorly.model.Model;
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
+    public static final String COMMAND_STRING = COMMAND_WORD;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;

--- a/src/main/java/tutorly/logic/commands/ListStudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/ListStudentCommand.java
@@ -8,9 +8,10 @@ import tutorly.model.Model;
 /**
  * Lists all persons in the address book to the user.
  */
-public class ListCommand extends Command {
+public class ListStudentCommand extends StudentCommand {
 
     public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_STRING = StudentCommand.COMMAND_STRING + " " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 

--- a/src/main/java/tutorly/logic/commands/RestoreStudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/RestoreStudentCommand.java
@@ -14,21 +14,22 @@ import tutorly.model.person.Person;
 /**
  * Restores a person identified using it's displayed ID from the address book.
  */
-public class RestoreCommand extends Command {
+public class RestoreStudentCommand extends StudentCommand {
 
     public static final String COMMAND_WORD = "restore";
+    public static final String COMMAND_STRING = StudentCommand.COMMAND_STRING + " " + COMMAND_WORD;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = COMMAND_STRING
             + ": Restores a previously archived person identified by the ID number "
             + "used in the displayed person list.\n"
             + "Parameters: ID (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + COMMAND_STRING + " 1";
 
     public static final String MESSAGE_RESTORE_PERSON_SUCCESS = "Restored Person: %1$s";
 
     private final Index targetId;
 
-    public RestoreCommand(Index targetId) {
+    public RestoreStudentCommand(Index targetId) {
         this.targetId = targetId;
     }
 
@@ -60,11 +61,11 @@ public class RestoreCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof RestoreCommand)) {
+        if (!(other instanceof RestoreStudentCommand)) {
             return false;
         }
 
-        RestoreCommand otherRestoreCommand = (RestoreCommand) other;
+        RestoreStudentCommand otherRestoreCommand = (RestoreStudentCommand) other;
         return targetId.equals(otherRestoreCommand.targetId);
     }
 

--- a/src/main/java/tutorly/logic/commands/SearchStudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/SearchStudentCommand.java
@@ -16,22 +16,24 @@ import tutorly.model.person.Person;
  * session with the session id.
  * Keyword matching is case-insensitive.
  */
-public class SearchCommand extends Command {
+public class SearchStudentCommand extends StudentCommand {
 
     public static final String COMMAND_WORD = "search";
+    public static final String COMMAND_STRING = StudentCommand.COMMAND_STRING + " " + COMMAND_WORD;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Searches for all students who attended a session or "
+    public static final String MESSAGE_USAGE = COMMAND_STRING
+            + ": Searches for all students who attended a session or "
             + "whose fields contain any of the specified keywords (case-insensitive) and displays them as a list.\n"
             + "Parameters: "
             + "[" + PREFIX_SESSION + "SESSION_ID] "
             + "[" + PREFIX_NAME + "NAME_KEYWORDS] "
             + "[" + PREFIX_PHONE + "PHONE_KEYWORDS]\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_SESSION + "1 " + PREFIX_NAME + "ali bob charli "
+            + "Example: " + COMMAND_STRING + " " + PREFIX_SESSION + "1 " + PREFIX_NAME + "ali bob charli "
             + PREFIX_PHONE + "9124 86192";
 
     private final Filter<Person> filter;
 
-    public SearchCommand(Filter<Person> filter) {
+    public SearchStudentCommand(Filter<Person> filter) {
         this.filter = filter;
     }
 
@@ -50,11 +52,11 @@ public class SearchCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof SearchCommand)) {
+        if (!(other instanceof SearchStudentCommand)) {
             return false;
         }
 
-        SearchCommand otherSearchCommand = (SearchCommand) other;
+        SearchStudentCommand otherSearchCommand = (SearchStudentCommand) other;
         return filter.equals(otherSearchCommand.filter);
     }
 

--- a/src/main/java/tutorly/logic/commands/SessionCommand.java
+++ b/src/main/java/tutorly/logic/commands/SessionCommand.java
@@ -1,0 +1,11 @@
+package tutorly.logic.commands;
+
+/**
+ * Represents a command related to sessions.
+ */
+public abstract class SessionCommand extends Command {
+
+    public static final String COMMAND_WORD = "session";
+    public static final String COMMAND_STRING = COMMAND_WORD;
+
+}

--- a/src/main/java/tutorly/logic/commands/StudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/StudentCommand.java
@@ -1,0 +1,11 @@
+package tutorly.logic.commands;
+
+/**
+ * Represents a command related to students.
+ */
+public abstract class StudentCommand extends Command {
+
+    public static final String COMMAND_WORD = "student";
+    public static final String COMMAND_STRING = COMMAND_WORD;
+
+}

--- a/src/main/java/tutorly/logic/parser/AddCommandParser.java
+++ b/src/main/java/tutorly/logic/parser/AddCommandParser.java
@@ -11,7 +11,7 @@ import static tutorly.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import tutorly.logic.commands.AddCommand;
+import tutorly.logic.commands.AddStudentCommand;
 import tutorly.logic.parser.exceptions.ParseException;
 import tutorly.model.person.Address;
 import tutorly.model.person.Email;
@@ -24,19 +24,19 @@ import tutorly.model.tag.Tag;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddCommandParser implements Parser<AddCommand> {
+public class AddCommandParser implements Parser<AddStudentCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddCommand parse(String args) throws ParseException {
+    public AddStudentCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
                 args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_MEMO);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddStudentCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_MEMO);
@@ -74,7 +74,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Person person = new Person(name, phone, email, address, tagList, memo);
 
-        return new AddCommand(person);
+        return new AddStudentCommand(person);
     }
 
     /**

--- a/src/main/java/tutorly/logic/parser/AddressBookParser.java
+++ b/src/main/java/tutorly/logic/parser/AddressBookParser.java
@@ -8,22 +8,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import tutorly.commons.core.LogsCenter;
-import tutorly.logic.commands.AddCommand;
 import tutorly.logic.commands.ClearCommand;
 import tutorly.logic.commands.Command;
-import tutorly.logic.commands.DeleteCommand;
-import tutorly.logic.commands.EditCommand;
 import tutorly.logic.commands.ExitCommand;
 import tutorly.logic.commands.HelpCommand;
-import tutorly.logic.commands.ListCommand;
-import tutorly.logic.commands.RestoreCommand;
-import tutorly.logic.commands.SearchCommand;
+import tutorly.logic.commands.StudentCommand;
 import tutorly.logic.parser.exceptions.ParseException;
 
 /**
  * Parses user input.
  */
-public class AddressBookParser {
+public class AddressBookParser implements Parser<Command> {
 
     /**
      * Used for initial separation of command word and args.
@@ -38,7 +33,7 @@ public class AddressBookParser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parse(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
@@ -52,25 +47,24 @@ public class AddressBookParser {
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        switch (commandWord) {
+        try {
+            return parseCommand(commandWord, arguments);
+        } catch (ParseException e) {
+            logger.finer("This user input caused a ParseException: " + userInput);
+            throw e;
+        }
+    }
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
-
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
-
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+    /**
+     * Parses a command word and arguments into a command.
+     */
+    public Command parseCommand(String command, String args) throws ParseException {
+        switch (command) {
+        case StudentCommand.COMMAND_WORD:
+            return new StudentCommandParser().parse(args);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
-
-        case SearchCommand.COMMAND_WORD:
-            return new SearchCommandParser().parse(arguments);
-
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
@@ -78,11 +72,7 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        case RestoreCommand.COMMAND_WORD:
-            return new RestoreCommandParser().parse(arguments);
-
         default:
-            logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/main/java/tutorly/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/tutorly/logic/parser/DeleteCommandParser.java
@@ -3,26 +3,26 @@ package tutorly.logic.parser;
 import static tutorly.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import tutorly.commons.core.index.Index;
-import tutorly.logic.commands.DeleteCommand;
+import tutorly.logic.commands.DeleteStudentCommand;
 import tutorly.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */
-public class DeleteCommandParser implements Parser<DeleteCommand> {
+public class DeleteCommandParser implements Parser<DeleteStudentCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeleteStudentCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            return new DeleteStudentCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteStudentCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/tutorly/logic/parser/EditCommandParser.java
+++ b/src/main/java/tutorly/logic/parser/EditCommandParser.java
@@ -15,22 +15,22 @@ import java.util.Optional;
 import java.util.Set;
 
 import tutorly.commons.core.index.Index;
-import tutorly.logic.commands.EditCommand;
-import tutorly.logic.commands.EditCommand.EditPersonDescriptor;
+import tutorly.logic.commands.EditStudentCommand;
+import tutorly.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import tutorly.logic.parser.exceptions.ParseException;
 import tutorly.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new EditCommand object
  */
-public class EditCommandParser implements Parser<EditCommand> {
+public class EditCommandParser implements Parser<EditStudentCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public EditCommand parse(String args) throws ParseException {
+    public EditStudentCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
                 args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_MEMO);
@@ -40,7 +40,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStudentCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_MEMO);
@@ -65,10 +66,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(EditStudentCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editPersonDescriptor);
+        return new EditStudentCommand(index, editPersonDescriptor);
     }
 
     /**

--- a/src/main/java/tutorly/logic/parser/RestoreCommandParser.java
+++ b/src/main/java/tutorly/logic/parser/RestoreCommandParser.java
@@ -3,26 +3,26 @@ package tutorly.logic.parser;
 import static tutorly.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import tutorly.commons.core.index.Index;
-import tutorly.logic.commands.RestoreCommand;
+import tutorly.logic.commands.RestoreStudentCommand;
 import tutorly.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new RestoreCommand object
  */
-public class RestoreCommandParser implements Parser<RestoreCommand> {
+public class RestoreCommandParser implements Parser<RestoreStudentCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the RestoreCommand
      * and returns a RestoreCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public RestoreCommand parse(String args) throws ParseException {
+    public RestoreStudentCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new RestoreCommand(index);
+            return new RestoreStudentCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RestoreCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RestoreStudentCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/tutorly/logic/parser/SearchCommandParser.java
+++ b/src/main/java/tutorly/logic/parser/SearchCommandParser.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import tutorly.logic.commands.SearchCommand;
+import tutorly.logic.commands.SearchStudentCommand;
 import tutorly.logic.parser.exceptions.ParseException;
 import tutorly.model.filter.AttendSessionFilter;
 import tutorly.model.filter.Filter;
@@ -22,23 +22,23 @@ import tutorly.model.person.Person;
 /**
  * Parses input arguments and creates a new SearchCommand object
  */
-public class SearchCommandParser implements Parser<SearchCommand> {
+public class SearchCommandParser implements Parser<SearchStudentCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the SearchCommand
      * and returns a SearchCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public SearchCommand parse(String args) throws ParseException {
+    public SearchStudentCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SESSION, PREFIX_NAME, PREFIX_PHONE);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SESSION, PREFIX_NAME, PREFIX_PHONE);
 
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchStudentCommand.MESSAGE_USAGE));
         }
 
-        return new SearchCommand(initFilter(argMultimap));
+        return new SearchStudentCommand(initFilter(argMultimap));
     }
 
     /**

--- a/src/main/java/tutorly/logic/parser/StudentCommandParser.java
+++ b/src/main/java/tutorly/logic/parser/StudentCommandParser.java
@@ -1,0 +1,45 @@
+package tutorly.logic.parser;
+
+import static tutorly.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import tutorly.logic.commands.AddStudentCommand;
+import tutorly.logic.commands.Command;
+import tutorly.logic.commands.DeleteStudentCommand;
+import tutorly.logic.commands.EditStudentCommand;
+import tutorly.logic.commands.ListStudentCommand;
+import tutorly.logic.commands.RestoreStudentCommand;
+import tutorly.logic.commands.SearchStudentCommand;
+import tutorly.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses user input.
+ */
+public class StudentCommandParser extends AddressBookParser {
+
+    @Override
+    public Command parseCommand(String command, String args) throws ParseException {
+        switch (command) {
+        case ListStudentCommand.COMMAND_WORD:
+            return new ListStudentCommand();
+
+        case AddStudentCommand.COMMAND_WORD:
+            return new AddCommandParser().parse(args);
+
+        case EditStudentCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(args);
+
+        case DeleteStudentCommand.COMMAND_WORD:
+            return new DeleteCommandParser().parse(args);
+
+        case RestoreStudentCommand.COMMAND_WORD:
+            return new RestoreCommandParser().parse(args);
+
+        case SearchStudentCommand.COMMAND_WORD:
+            return new SearchCommandParser().parse(args);
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+
+}

--- a/src/test/java/tutorly/logic/LogicManagerTest.java
+++ b/src/test/java/tutorly/logic/LogicManagerTest.java
@@ -19,9 +19,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import tutorly.logic.commands.AddCommand;
+import tutorly.logic.commands.AddStudentCommand;
 import tutorly.logic.commands.CommandResult;
-import tutorly.logic.commands.ListCommand;
+import tutorly.logic.commands.DeleteStudentCommand;
+import tutorly.logic.commands.ListStudentCommand;
 import tutorly.logic.commands.exceptions.CommandException;
 import tutorly.logic.parser.exceptions.ParseException;
 import tutorly.model.Model;
@@ -61,14 +62,14 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = DeleteStudentCommand.COMMAND_STRING + " 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        String listCommand = ListStudentCommand.COMMAND_STRING;
+        assertCommandSuccess(listCommand, ListStudentCommand.MESSAGE_SUCCESS, model);
     }
 
     @Test
@@ -166,7 +167,7 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
+        String addCommand = AddStudentCommand.COMMAND_STRING + NAME_DESC_AMY + PHONE_DESC_AMY
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + MEMO_DESC_AMY;
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();

--- a/src/test/java/tutorly/logic/commands/AddSessionCommandTest.java
+++ b/src/test/java/tutorly/logic/commands/AddSessionCommandTest.java
@@ -24,56 +24,56 @@ import tutorly.model.session.Session;
 import tutorly.model.session.UniqueSessionList;
 
 /**
- * Test class for CreateSessionCommand.
+ * Test class for AddSessionCommand.
  */
-public class CreateSessionCommandTest {
+public class AddSessionCommandTest {
 
     private ModelStub model;
     private Session session;
-    private CreateSessionCommand createSessionCommand;
+    private AddSessionCommand addSessionCommand;
 
     @BeforeEach
     void setUp() {
         model = new ModelStub();
         session = new Session(101, LocalDate.of(2025, 3, 18), "Mathematics");
-        createSessionCommand = new CreateSessionCommand(session);
+        addSessionCommand = new AddSessionCommand(session);
     }
 
     @Test
     void execute_success() throws CommandException {
-        CommandResult result = createSessionCommand.execute(model);
-        assertEquals(String.format(CreateSessionCommand.MESSAGE_SUCCESS, Messages.format(session)),
+        CommandResult result = addSessionCommand.execute(model);
+        assertEquals(String.format(AddSessionCommand.MESSAGE_SUCCESS, Messages.format(session)),
                 result.getFeedbackToUser());
     }
 
     @Test
     void execute_duplicateSession_throwsException() throws CommandException {
-        createSessionCommand.execute(model); // Add session first
-        assertThrows(CommandException.class, () -> createSessionCommand.execute(model));
+        addSessionCommand.execute(model); // Add session first
+        assertThrows(CommandException.class, () -> addSessionCommand.execute(model));
     }
 
     @Test
     void equals_sameObject() {
-        assertEquals(createSessionCommand, createSessionCommand);
+        assertEquals(addSessionCommand, addSessionCommand);
     }
 
     @Test
     void equals_differentObjectSameData() {
-        CreateSessionCommand commandCopy = new CreateSessionCommand(session);
-        assertEquals(createSessionCommand, commandCopy);
+        AddSessionCommand commandCopy = new AddSessionCommand(session);
+        assertEquals(addSessionCommand, commandCopy);
     }
 
     @Test
     void equals_differentObjects() {
         Session differentSession = new Session(102, LocalDate.of(2025, 3, 19), "Science");
-        CreateSessionCommand differentCommand = new CreateSessionCommand(differentSession);
-        assertNotEquals(createSessionCommand, differentCommand);
+        AddSessionCommand differentCommand = new AddSessionCommand(differentSession);
+        assertNotEquals(addSessionCommand, differentCommand);
     }
 
     @Test
     void toStringTest() {
-        String expected = "CreateSessionCommand{toCreate=" + session + "}";
-        assertTrue(createSessionCommand.toString().contains(expected));
+        String expected = "AddSessionCommand{toCreate=" + session + "}";
+        assertTrue(addSessionCommand.toString().contains(expected));
     }
 
     /**

--- a/src/test/java/tutorly/logic/commands/AddStudentCommandIntegrationTest.java
+++ b/src/test/java/tutorly/logic/commands/AddStudentCommandIntegrationTest.java
@@ -15,9 +15,9 @@ import tutorly.model.person.Person;
 import tutorly.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code AddCommand}.
+ * Contains integration tests (interaction with the Model) for {@code AddStudentCommand}.
  */
-public class AddCommandIntegrationTest {
+public class AddStudentCommandIntegrationTest {
 
     private Model model;
 
@@ -33,16 +33,16 @@ public class AddCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addPerson(validPerson);
 
-        assertCommandSuccess(new AddCommand(validPerson), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+        assertCommandSuccess(new AddStudentCommand(validPerson), model,
+                String.format(AddStudentCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
                 expectedModel);
     }
 
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
-        assertCommandFailure(new AddCommand(personInList), model,
-                AddCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(new AddStudentCommand(personInList), model,
+                AddStudentCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
 }

--- a/src/test/java/tutorly/logic/commands/AddStudentCommandTest.java
+++ b/src/test/java/tutorly/logic/commands/AddStudentCommandTest.java
@@ -26,11 +26,11 @@ import tutorly.model.person.Person;
 import tutorly.model.session.Session;
 import tutorly.testutil.PersonBuilder;
 
-public class AddCommandTest {
+public class AddStudentCommandTest {
 
     @Test
     public void constructor_nullPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddCommand(null));
+        assertThrows(NullPointerException.class, () -> new AddStudentCommand(null));
     }
 
     @Test
@@ -38,9 +38,9 @@ public class AddCommandTest {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         Person validPerson = new PersonBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
+        CommandResult commandResult = new AddStudentCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+        assertEquals(String.format(AddStudentCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }
@@ -48,24 +48,25 @@ public class AddCommandTest {
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
-        AddCommand addCommand = new AddCommand(validPerson);
+        AddStudentCommand addCommand = new AddStudentCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class,
+                AddStudentCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
     }
 
     @Test
     public void equals() {
         Person alice = new PersonBuilder().withName("Alice").build();
         Person bob = new PersonBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
+        AddStudentCommand addAliceCommand = new AddStudentCommand(alice);
+        AddStudentCommand addBobCommand = new AddStudentCommand(bob);
 
         // same object -> returns true
         assertTrue(addAliceCommand.equals(addAliceCommand));
 
         // same values -> returns true
-        AddCommand addAliceCommandCopy = new AddCommand(alice);
+        AddStudentCommand addAliceCommandCopy = new AddStudentCommand(alice);
         assertTrue(addAliceCommand.equals(addAliceCommandCopy));
 
         // different types -> returns false
@@ -80,8 +81,8 @@ public class AddCommandTest {
 
     @Test
     public void toStringMethod() {
-        AddCommand addCommand = new AddCommand(ALICE);
-        String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
+        AddStudentCommand addCommand = new AddStudentCommand(ALICE);
+        String expected = AddStudentCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
         assertEquals(expected, addCommand.toString());
     }
 

--- a/src/test/java/tutorly/logic/commands/CommandTestUtil.java
+++ b/src/test/java/tutorly/logic/commands/CommandTestUtil.java
@@ -63,8 +63,8 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditCommand.EditPersonDescriptor DESC_AMY;
-    public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditStudentCommand.EditPersonDescriptor DESC_AMY;
+    public static final EditStudentCommand.EditPersonDescriptor DESC_BOB;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/tutorly/logic/commands/DeleteStudentCommandTest.java
+++ b/src/test/java/tutorly/logic/commands/DeleteStudentCommandTest.java
@@ -21,18 +21,18 @@ import tutorly.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code DeleteCommand}.
+ * {@code DeleteStudentCommand}.
  */
-public class DeleteCommandTest {
+public class DeleteStudentCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteCommand = new DeleteStudentCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+        String expectedMessage = String.format(DeleteStudentCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -44,7 +44,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteStudentCommand deleteCommand = new DeleteStudentCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -54,9 +54,9 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteCommand = new DeleteStudentCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+        String expectedMessage = String.format(DeleteStudentCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -74,21 +74,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteStudentCommand deleteCommand = new DeleteStudentCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteStudentCommand deleteFirstCommand = new DeleteStudentCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteSecondCommand = new DeleteStudentCommand(INDEX_SECOND_PERSON);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteFirstCommandCopy = new DeleteStudentCommand(INDEX_FIRST_PERSON);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -104,8 +104,8 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        DeleteStudentCommand deleteCommand = new DeleteStudentCommand(targetIndex);
+        String expected = DeleteStudentCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/tutorly/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/tutorly/logic/commands/EditPersonDescriptorTest.java
@@ -13,7 +13,7 @@ import static tutorly.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
 
-import tutorly.logic.commands.EditCommand.EditPersonDescriptor;
+import tutorly.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import tutorly.testutil.EditPersonDescriptorBuilder;
 
 public class EditPersonDescriptorTest {

--- a/src/test/java/tutorly/logic/commands/EditStudentCommandTest.java
+++ b/src/test/java/tutorly/logic/commands/EditStudentCommandTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import tutorly.commons.core.index.Index;
 import tutorly.logic.Messages;
-import tutorly.logic.commands.EditCommand.EditPersonDescriptor;
+import tutorly.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import tutorly.model.AddressBook;
 import tutorly.model.Model;
 import tutorly.model.ModelManager;
@@ -30,9 +30,9 @@ import tutorly.testutil.EditPersonDescriptorBuilder;
 import tutorly.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for EditStudentCommand.
  */
-public class EditCommandTest {
+public class EditStudentCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -40,9 +40,9 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Person editedPerson = new PersonBuilder(AMY).build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditStudentCommand editCommand = new EditStudentCommand(INDEX_FIRST_PERSON, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+        String expectedMessage = String.format(EditStudentCommand.MESSAGE_EDIT_PERSON_SUCCESS,
                 Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
@@ -62,9 +62,10 @@ public class EditCommandTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+        EditStudentCommand editCommand = new EditStudentCommand(indexLastPerson, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(
+                EditStudentCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
@@ -74,10 +75,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
+        EditStudentCommand editCommand = new EditStudentCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(
+                EditStudentCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
@@ -90,10 +92,11 @@ public class EditCommandTest {
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        EditStudentCommand editCommand = new EditStudentCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(
+                EditStudentCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
@@ -105,9 +108,9 @@ public class EditCommandTest {
     public void execute_duplicatePersonUnfilteredList_failure() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditStudentCommand editCommand = new EditStudentCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, EditStudentCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
@@ -116,17 +119,17 @@ public class EditCommandTest {
 
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        EditStudentCommand editCommand = new EditStudentCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, EditStudentCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+        EditStudentCommand editCommand = new EditStudentCommand(outOfBoundIndex, descriptor);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -142,7 +145,7 @@ public class EditCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+        EditStudentCommand editCommand = new EditStudentCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -150,11 +153,11 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditStudentCommand standardCommand = new EditStudentCommand(INDEX_FIRST_PERSON, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditStudentCommand commandWithSameValues = new EditStudentCommand(INDEX_FIRST_PERSON, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -167,18 +170,18 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditStudentCommand(INDEX_SECOND_PERSON, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditStudentCommand(INDEX_FIRST_PERSON, DESC_BOB)));
     }
 
     @Test
     public void toStringMethod() {
         Index index = Index.fromOneBased(1);
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-        EditCommand editCommand = new EditCommand(index, editPersonDescriptor);
-        String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
+        EditStudentCommand editCommand = new EditStudentCommand(index, editPersonDescriptor);
+        String expected = EditStudentCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
                 + editPersonDescriptor + "}";
         assertEquals(expected, editCommand.toString());
     }

--- a/src/test/java/tutorly/logic/commands/ListStudentCommandTest.java
+++ b/src/test/java/tutorly/logic/commands/ListStudentCommandTest.java
@@ -13,9 +13,9 @@ import tutorly.model.ModelManager;
 import tutorly.model.UserPrefs;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for ListStudentCommand.
  */
-public class ListCommandTest {
+public class ListStudentCommandTest {
 
     private Model model;
     private Model expectedModel;
@@ -28,12 +28,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListStudentCommand(), model, ListStudentCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListStudentCommand(), model, ListStudentCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/tutorly/logic/commands/RestoreStudentCommandTest.java
+++ b/src/test/java/tutorly/logic/commands/RestoreStudentCommandTest.java
@@ -14,14 +14,14 @@ import tutorly.model.ModelManager;
 import tutorly.model.UserPrefs;
 import tutorly.model.person.Person;
 
-public class RestoreCommandTest {
+public class RestoreStudentCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() throws CommandException {
         Person personToRestore = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         model.deletePerson(personToRestore);
-        RestoreCommand restoreCommand = new RestoreCommand(INDEX_FIRST_PERSON);
+        RestoreStudentCommand restoreCommand = new RestoreStudentCommand(INDEX_FIRST_PERSON);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         restoreCommand.execute(model);
@@ -32,14 +32,14 @@ public class RestoreCommandTest {
 
     @Test
     public void equals() {
-        RestoreCommand restoreFirstCommand = new RestoreCommand(INDEX_FIRST_PERSON);
-        RestoreCommand restoreSecondCommand = new RestoreCommand(INDEX_FIRST_PERSON);
+        RestoreStudentCommand restoreFirstCommand = new RestoreStudentCommand(INDEX_FIRST_PERSON);
+        RestoreStudentCommand restoreSecondCommand = new RestoreStudentCommand(INDEX_FIRST_PERSON);
 
         // same object -> returns true
         assertTrue(restoreFirstCommand.equals(restoreFirstCommand));
 
         // same values -> returns true
-        RestoreCommand restoreFirstCommandCopy = new RestoreCommand(INDEX_FIRST_PERSON);
+        RestoreStudentCommand restoreFirstCommandCopy = new RestoreStudentCommand(INDEX_FIRST_PERSON);
         assertTrue(restoreFirstCommand.equals(restoreFirstCommandCopy));
 
         // different types -> returns false
@@ -54,8 +54,8 @@ public class RestoreCommandTest {
 
     @Test
     public void toStringTest() {
-        RestoreCommand restoreCommand = new RestoreCommand(INDEX_FIRST_PERSON);
-        assertEquals(restoreCommand.toString(), "tutorly.logic.commands.RestoreCommand{targetId=tutorly."
+        RestoreStudentCommand restoreCommand = new RestoreStudentCommand(INDEX_FIRST_PERSON);
+        assertEquals(restoreCommand.toString(), "tutorly.logic.commands.RestoreStudentCommand{targetId=tutorly."
                 + "commons.core.index.Index{zeroBasedIndex=0}}");
     }
 }

--- a/src/test/java/tutorly/logic/commands/SearchStudentCommandTest.java
+++ b/src/test/java/tutorly/logic/commands/SearchStudentCommandTest.java
@@ -32,9 +32,9 @@ import tutorly.model.filter.PhoneContainsKeywordsFilter;
 import tutorly.model.person.Person;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code SearchCommand}.
+ * Contains integration tests (interaction with the Model) for {@code SearchStudentCommand}.
  */
-public class SearchCommandTest {
+public class SearchStudentCommandTest {
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -43,14 +43,14 @@ public class SearchCommandTest {
         Filter<Person> firstFilter = new NameContainsKeywordsFilter(Collections.singletonList("first"));
         Filter<Person> secondFilter = new NameContainsKeywordsFilter(Collections.singletonList("second"));
 
-        SearchCommand searchFirstCommand = new SearchCommand(firstFilter);
-        SearchCommand searchSecondCommand = new SearchCommand(secondFilter);
+        SearchStudentCommand searchFirstCommand = new SearchStudentCommand(firstFilter);
+        SearchStudentCommand searchSecondCommand = new SearchStudentCommand(secondFilter);
 
         // same object -> returns true
         assertTrue(searchFirstCommand.equals(searchFirstCommand));
 
         // same values -> returns true
-        SearchCommand searchFirstCommandCopy = new SearchCommand(firstFilter);
+        SearchStudentCommand searchFirstCommandCopy = new SearchStudentCommand(firstFilter);
         assertTrue(searchFirstCommand.equals(searchFirstCommandCopy));
 
         // different types -> returns false
@@ -64,7 +64,7 @@ public class SearchCommandTest {
 
         // different predicate type -> returns false
         Filter<Person> thirdFilter = new PhoneContainsKeywordsFilter(Collections.singletonList("first"));
-        SearchCommand searchThirdCommand = new SearchCommand(thirdFilter);
+        SearchStudentCommand searchThirdCommand = new SearchStudentCommand(thirdFilter);
         assertFalse(searchFirstCommand.equals(searchThirdCommand));
     }
 
@@ -73,7 +73,7 @@ public class SearchCommandTest {
         List<Person> expectedResult = Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE);
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, expectedResult.size());
 
-        SearchCommand command = new SearchCommand(Filter.any(List.of()));
+        SearchStudentCommand command = new SearchStudentCommand(Filter.any(List.of()));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(expectedResult, model.getFilteredPersonList());
     }
@@ -87,7 +87,7 @@ public class SearchCommandTest {
         NameContainsKeywordsFilter nameFilter = prepareNameFilter("Kurz Elle Kunz");
         PhoneContainsKeywordsFilter phoneFilter = preparePhoneFilter("948");
         Filter<Person> filter = Filter.any(Arrays.asList(sessionFilter, nameFilter, phoneFilter));
-        SearchCommand command = new SearchCommand(filter);
+        SearchStudentCommand command = new SearchStudentCommand(filter);
 
         expectedModel.updateFilteredPersonList(filter);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -102,9 +102,9 @@ public class SearchCommandTest {
         PhoneContainsKeywordsFilter phoneFilter =
                 new PhoneContainsKeywordsFilter(Arrays.asList("keyword3", "keyword4"));
         Filter<Person> filter = Filter.any(Arrays.asList(sessionFilter, nameFilter, phoneFilter));
-        SearchCommand searchCommand = new SearchCommand(filter);
+        SearchStudentCommand searchCommand = new SearchStudentCommand(filter);
 
-        String expected = SearchCommand.class.getCanonicalName()
+        String expected = SearchStudentCommand.class.getCanonicalName()
                 + "{filter=" + AnyFilter.class.getCanonicalName()
                 + "{filters=[" + sessionFilter + ", " + nameFilter + ", " + phoneFilter + "]}}";
         assertEquals(expected, searchCommand.toString());

--- a/src/test/java/tutorly/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/tutorly/logic/parser/AddCommandParserTest.java
@@ -40,7 +40,7 @@ import static tutorly.testutil.TypicalAddressBook.BOB;
 import org.junit.jupiter.api.Test;
 
 import tutorly.logic.Messages;
-import tutorly.logic.commands.AddCommand;
+import tutorly.logic.commands.AddStudentCommand;
 import tutorly.model.person.Address;
 import tutorly.model.person.Email;
 import tutorly.model.person.Memo;
@@ -59,7 +59,7 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + MEMO_DESC_BOB, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + MEMO_DESC_BOB, new AddStudentCommand(expectedPerson));
 
 
         // multiple tags - all accepted
@@ -68,7 +68,7 @@ public class AddCommandParserTest {
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + MEMO_DESC_BOB,
-                new AddCommand(expectedPersonMultipleTags));
+                new AddStudentCommand(expectedPersonMultipleTags));
     }
 
     @Test
@@ -152,28 +152,28 @@ public class AddCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + MEMO_DESC_AMY,
-                new AddCommand(new PersonBuilder(AMY).withTags().build()));
+                new AddStudentCommand(new PersonBuilder(AMY).withTags().build()));
 
         // missing phone prefix
         assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND + MEMO_DESC_AMY,
-                new AddCommand(new PersonBuilder(AMY).withEmptyPhone().build()));
+                new AddStudentCommand(new PersonBuilder(AMY).withEmptyPhone().build()));
 
         // missing email prefix
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND + MEMO_DESC_AMY,
-                new AddCommand(new PersonBuilder(AMY).withEmptyEmail().build()));
+                new AddStudentCommand(new PersonBuilder(AMY).withEmptyEmail().build()));
 
         // missing address prefix
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND + MEMO_DESC_AMY,
-                new AddCommand(new PersonBuilder(AMY).withEmptyAddress().build()));
+                new AddStudentCommand(new PersonBuilder(AMY).withEmptyAddress().build()));
 
         // missing memo prefix
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND,
-                new AddCommand(new PersonBuilder(AMY).withEmptyMemo().build()));
+                new AddStudentCommand(new PersonBuilder(AMY).withEmptyMemo().build()));
     }
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddStudentCommand.MESSAGE_USAGE);
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
@@ -217,6 +217,6 @@ public class AddCommandParserTest {
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddStudentCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/tutorly/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/tutorly/logic/parser/AddressBookParserTest.java
@@ -16,16 +16,16 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import tutorly.logic.commands.AddCommand;
+import tutorly.logic.commands.AddStudentCommand;
 import tutorly.logic.commands.ClearCommand;
-import tutorly.logic.commands.DeleteCommand;
-import tutorly.logic.commands.EditCommand;
-import tutorly.logic.commands.EditCommand.EditPersonDescriptor;
+import tutorly.logic.commands.DeleteStudentCommand;
+import tutorly.logic.commands.EditStudentCommand;
+import tutorly.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import tutorly.logic.commands.ExitCommand;
 import tutorly.logic.commands.HelpCommand;
-import tutorly.logic.commands.ListCommand;
-import tutorly.logic.commands.RestoreCommand;
-import tutorly.logic.commands.SearchCommand;
+import tutorly.logic.commands.ListStudentCommand;
+import tutorly.logic.commands.RestoreStudentCommand;
+import tutorly.logic.commands.SearchStudentCommand;
 import tutorly.logic.parser.exceptions.ParseException;
 import tutorly.model.filter.AttendSessionFilter;
 import tutorly.model.filter.Filter;
@@ -43,44 +43,44 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Person person = new PersonBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
-        assertEquals(new AddCommand(person), command);
+        AddStudentCommand command = (AddStudentCommand) parser.parse(PersonUtil.getAddCommand(person));
+        assertEquals(new AddStudentCommand(person), command);
     }
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parse(ClearCommand.COMMAND_STRING) instanceof ClearCommand);
+        assertTrue(parser.parse(ClearCommand.COMMAND_STRING + " 3") instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_delete() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+        DeleteStudentCommand command = (DeleteStudentCommand) parser.parse(
+                DeleteStudentCommand.COMMAND_STRING + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteStudentCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test
     public void parseCommand_edit() throws Exception {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+        EditStudentCommand command = (EditStudentCommand) parser.parse(EditStudentCommand.COMMAND_STRING + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditStudentCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test
     public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+        assertTrue(parser.parse(ExitCommand.COMMAND_STRING) instanceof ExitCommand);
+        assertTrue(parser.parse(ExitCommand.COMMAND_STRING + " 3") instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_search() throws Exception {
         int sessionId = 1;
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        SearchCommand command = (SearchCommand) parser.parseCommand(
-                SearchCommand.COMMAND_WORD
+        SearchStudentCommand command = (SearchStudentCommand) parser.parse(
+                SearchStudentCommand.COMMAND_STRING
                         + " " + PREFIX_SESSION + sessionId
                         + " " + PREFIX_NAME + keywords.stream().collect(Collectors.joining(" "))
                         + " " + PREFIX_PHONE + keywords.stream().collect(Collectors.joining(" ")));
@@ -88,34 +88,34 @@ public class AddressBookParserTest {
                 new AttendSessionFilter(sessionId),
                 new NameContainsKeywordsFilter(keywords),
                 new PhoneContainsKeywordsFilter(keywords)));
-        assertEquals(new SearchCommand(filter), command);
+        assertEquals(new SearchStudentCommand(filter), command);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parse(HelpCommand.COMMAND_STRING) instanceof HelpCommand);
+        assertTrue(parser.parse(HelpCommand.COMMAND_STRING + " 3") instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parse(ListStudentCommand.COMMAND_STRING) instanceof ListStudentCommand);
+        assertTrue(parser.parse(ListStudentCommand.COMMAND_STRING + " 3") instanceof ListStudentCommand);
     }
 
     @Test
     public void parseCommand_restore() throws Exception {
-        assertTrue(parser.parseCommand(RestoreCommand.COMMAND_WORD + " 3") instanceof RestoreCommand);
+        assertTrue(parser.parse(RestoreStudentCommand.COMMAND_STRING + " 3") instanceof RestoreStudentCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+            -> parser.parse(""));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parse("unknownCommand"));
     }
 }

--- a/src/test/java/tutorly/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/tutorly/logic/parser/DeleteCommandParserTest.java
@@ -7,7 +7,7 @@ import static tutorly.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import tutorly.logic.commands.DeleteCommand;
+import tutorly.logic.commands.DeleteStudentCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -22,11 +22,12 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteStudentCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, DeleteStudentCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/tutorly/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tutorly/logic/parser/EditCommandParserTest.java
@@ -38,8 +38,8 @@ import org.junit.jupiter.api.Test;
 
 import tutorly.commons.core.index.Index;
 import tutorly.logic.Messages;
-import tutorly.logic.commands.EditCommand;
-import tutorly.logic.commands.EditCommand.EditPersonDescriptor;
+import tutorly.logic.commands.EditStudentCommand;
+import tutorly.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import tutorly.model.person.Address;
 import tutorly.model.person.Email;
 import tutorly.model.person.Name;
@@ -52,7 +52,7 @@ public class EditCommandParserTest {
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStudentCommand.MESSAGE_USAGE);
 
     private EditCommandParser parser = new EditCommandParser();
 
@@ -62,7 +62,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1", EditStudentCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -114,7 +114,7 @@ public class EditCommandParserTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withMemo(VALID_MEMO_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditStudentCommand expectedCommand = new EditStudentCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -126,7 +126,7 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditStudentCommand expectedCommand = new EditStudentCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -137,37 +137,37 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditStudentCommand expectedCommand = new EditStudentCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditStudentCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditStudentCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
         userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditStudentCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditStudentCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // memo
         userInput = targetIndex.getOneBased() + MEMO_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withMemo(VALID_MEMO_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditStudentCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -209,7 +209,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditStudentCommand expectedCommand = new EditStudentCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/tutorly/logic/parser/RestoreCommandParserTest.java
+++ b/src/test/java/tutorly/logic/parser/RestoreCommandParserTest.java
@@ -7,18 +7,19 @@ import static tutorly.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import tutorly.logic.commands.RestoreCommand;
+import tutorly.logic.commands.RestoreStudentCommand;
 
 public class RestoreCommandParserTest {
     private RestoreCommandParser parser = new RestoreCommandParser();
 
     @Test
     public void parse_validArgs_returnsRestoreCommand() {
-        assertParseSuccess(parser, "1", new RestoreCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new RestoreStudentCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RestoreCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, RestoreStudentCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/tutorly/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/tutorly/logic/parser/SearchCommandParserTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import tutorly.logic.commands.SearchCommand;
+import tutorly.logic.commands.SearchStudentCommand;
 import tutorly.model.filter.Filter;
 import tutorly.model.filter.NameContainsKeywordsFilter;
 import tutorly.model.filter.PhoneContainsKeywordsFilter;
@@ -28,13 +28,13 @@ public class SearchCommandParserTest {
         assertParseFailure(
                 parser,
                 PREAMBLE_NON_EMPTY + NAME_DESC_AMY,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchStudentCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_blankKeywords_returnsSearchCommand() {
         Filter<Person> filter = Filter.any(List.of());
-        SearchCommand expectedSearchCommand = new SearchCommand(filter);
+        SearchStudentCommand expectedSearchCommand = new SearchStudentCommand(filter);
 
         assertParseSuccess(
                 parser,
@@ -48,7 +48,7 @@ public class SearchCommandParserTest {
         Filter<Person> filters = Filter.any(Arrays.asList(
                 new NameContainsKeywordsFilter(Arrays.asList("Alice", "Bob")),
                 new PhoneContainsKeywordsFilter(Arrays.asList("913", "8476"))));
-        SearchCommand expectedSearchCommand = new SearchCommand(filters);
+        SearchStudentCommand expectedSearchCommand = new SearchStudentCommand(filters);
         assertParseSuccess(
                 parser,
                 " " + PREFIX_NAME + "Alice Bob " + PREFIX_PHONE + "913 8476",

--- a/src/test/java/tutorly/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/tutorly/testutil/EditPersonDescriptorBuilder.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import tutorly.logic.commands.EditCommand.EditPersonDescriptor;
+import tutorly.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import tutorly.model.person.Address;
 import tutorly.model.person.Email;
 import tutorly.model.person.Memo;

--- a/src/test/java/tutorly/testutil/PersonUtil.java
+++ b/src/test/java/tutorly/testutil/PersonUtil.java
@@ -9,8 +9,8 @@ import static tutorly.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 
-import tutorly.logic.commands.AddCommand;
-import tutorly.logic.commands.EditCommand.EditPersonDescriptor;
+import tutorly.logic.commands.AddStudentCommand;
+import tutorly.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import tutorly.model.person.Person;
 import tutorly.model.tag.Tag;
 
@@ -23,7 +23,7 @@ public class PersonUtil {
      * Returns an add command string for adding the {@code person}.
      */
     public static String getAddCommand(Person person) {
-        return AddCommand.COMMAND_WORD + " " + getPersonDetails(person);
+        return AddStudentCommand.COMMAND_STRING + " " + getPersonDetails(person);
     }
 
     /**


### PR DESCRIPTION
In preparation for future commands which may be difficult to distinguish (like `addStudent`, `addSession`, `addClass`), it may be better for us to implement subcommands and subparsers, so we have `student add`, `session add`, and `class add`. With subparsers, we can have each subparser handle a subcommand, reflecting the principles of OOP. 