### PR TITLE
Prevent split pane from being too small

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -69,12 +69,12 @@
                               <children>
                                  <SplitPane dividerPositions="0.29797979797979796" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                    <items>
-                                     <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
+                                     <AnchorPane minHeight="0.0" minWidth="-Infinity" prefHeight="160.0" prefWidth="250.0">
                                           <children>
                                              <StackPane fx:id="sessionListPanelPlaceholder" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                                           </children>
                                        </AnchorPane>
-                                     <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
+                                     <AnchorPane minHeight="0.0" minWidth="-Infinity" prefHeight="160.0" prefWidth="250.0">
                                           <children>
                                              <StackPane fx:id="attendanceRecordListPanelPlaceholder" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                                           </children>


### PR DESCRIPTION
The split pane allows the session list or attendance record list to be too small, giving rise to UI bugs. This PR prevents that from happening.