### PR TITLE
Fix inability to undo edit of student name

### DIFF
--- a/src/main/java/tutorly/logic/commands/EditStudentCommand.java
+++ b/src/main/java/tutorly/logic/commands/EditStudentCommand.java
@@ -109,7 +109,7 @@ public class EditStudentCommand extends StudentCommand {
         return new CommandResult.Builder(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)))
                 .withTab(Tab.student(editedPerson))
                 .withReverseCommand(new EditStudentCommand(
-                        identity, EditPersonDescriptor.fromPerson(personToEdit.get())))
+                        new Identity(personToEdit.get().getId()), EditPersonDescriptor.fromPerson(personToEdit.get())))
                 .build();
     }
 


### PR DESCRIPTION
Cause: `identity`, if initialised by name, no longer refers to the correct name in the reverse command. We work around this by initialising a new `identity` with the resolved person's ID. Since a person's ID is never changed, this will always refer to the same person. 

Closes #294.