### PR TITLE
Fix removal of feedback when undoing unenrol

### DIFF
--- a/src/main/java/tutorly/logic/commands/EnrolSessionCommand.java
+++ b/src/main/java/tutorly/logic/commands/EnrolSessionCommand.java
@@ -38,23 +38,25 @@ public class EnrolSessionCommand extends SessionCommand {
     private final Identity identity;
     private final int sessionId;
     private final boolean presence;
+    private final Feedback feedback;
 
     /**
      * Creates an EnrolSessionCommand for the given {@code Person} to the given {@code Session} with the given
      * {@code presence} status.
      */
-    public EnrolSessionCommand(Identity identity, int sessionId, boolean presence) {
+    public EnrolSessionCommand(Identity identity, int sessionId, boolean presence, Feedback feedback) {
         requireNonNull(identity);
         this.identity = identity;
         this.sessionId = sessionId;
         this.presence = presence;
+        this.feedback = feedback;
     }
 
     /**
      * Creates an EnrolSessionCommand for the given {@code Person} to the given {@code Session} with default presence.
      */
     public EnrolSessionCommand(Identity identity, int sessionId) {
-        this(identity, sessionId, DEFAULT_PRESENCE);
+        this(identity, sessionId, DEFAULT_PRESENCE, Feedback.empty());
     }
 
     @Override
@@ -71,7 +73,7 @@ public class EnrolSessionCommand extends SessionCommand {
             throw new CommandException(Messages.MESSAGE_INVALID_SESSION_ID);
         }
 
-        AttendanceRecord record = new AttendanceRecord(person.get().getId(), sessionId, presence, Feedback.empty());
+        AttendanceRecord record = new AttendanceRecord(person.get().getId(), sessionId, presence, feedback);
         if (model.hasAttendanceRecord(record)) {
             throw new CommandException(MESSAGE_DUPLICATE_ENROLMENT);
         }

--- a/src/main/java/tutorly/logic/commands/EnrolSessionCommand.java
+++ b/src/main/java/tutorly/logic/commands/EnrolSessionCommand.java
@@ -42,7 +42,7 @@ public class EnrolSessionCommand extends SessionCommand {
 
     /**
      * Creates an EnrolSessionCommand for the given {@code Person} to the given {@code Session} with the given
-     * {@code presence} status.
+     * {@code presence} status and {@code feedback}.
      */
     public EnrolSessionCommand(Identity identity, int sessionId, boolean presence, Feedback feedback) {
         requireNonNull(identity);
@@ -53,7 +53,7 @@ public class EnrolSessionCommand extends SessionCommand {
     }
 
     /**
-     * Creates an EnrolSessionCommand for the given {@code Person} to the given {@code Session} with default presence.
+     * Creates an EnrolSessionCommand for the given {@code Person} to the given {@code Session}.
      */
     public EnrolSessionCommand(Identity identity, int sessionId) {
         this(identity, sessionId, DEFAULT_PRESENCE, Feedback.empty());

--- a/src/main/java/tutorly/logic/commands/EnrolSessionCommand.java
+++ b/src/main/java/tutorly/logic/commands/EnrolSessionCommand.java
@@ -46,6 +46,7 @@ public class EnrolSessionCommand extends SessionCommand {
      */
     public EnrolSessionCommand(Identity identity, int sessionId, boolean presence, Feedback feedback) {
         requireNonNull(identity);
+        requireNonNull(feedback);
         this.identity = identity;
         this.sessionId = sessionId;
         this.presence = presence;

--- a/src/main/java/tutorly/logic/commands/UnenrolSessionCommand.java
+++ b/src/main/java/tutorly/logic/commands/UnenrolSessionCommand.java
@@ -71,7 +71,8 @@ public class UnenrolSessionCommand extends SessionCommand {
         return new CommandResult.Builder(
                 String.format(MESSAGE_SUCCESS, person.get().getName().fullName, Messages.format(session.get())))
                 .withTab(Tab.session(session.get()))
-                .withReverseCommand(new EnrolSessionCommand(identity, sessionId, record.get().getAttendance()))
+                .withReverseCommand(new EnrolSessionCommand(
+                        identity, sessionId, record.get().getAttendance(), record.get().getFeedback()))
                 .build();
     }
 


### PR DESCRIPTION
Cause: When feedback was added, the reverse command of unenrol was neglected. This PR adds feedback to the reverse command of unenrol (and consequently the enrol command as well)

Closes #310. 